### PR TITLE
fix: allow latest angular versions in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "zone.js": "^0.8.18"
   },
   "peerDependencies": {
-    "@angular/core": ">=2.0.0 <7.0.0"
+    "@angular/core": ">=2.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Any reasoning for arbitrarily limiting the Angular version. This library is working fine with Angular 9, and having the peerDependency check requires doing a new release every time the Angular team bumps their version.