### PR TITLE
fix: enable word-wrap to fix positioning of highlight elements

### DIFF
--- a/src/text-input-highlight.scss
+++ b/src/text-input-highlight.scss
@@ -9,6 +9,7 @@
 
   .text-highlight-element {
     overflow: hidden !important;
+    word-break: break-word;
     white-space: pre-wrap;
     position: absolute;
     top: 0;


### PR DESCRIPTION
Hey, If words in the text are too long, the tag positions are in the wrong place:
![image](https://user-images.githubusercontent.com/26489348/97272428-2ef26100-1832-11eb-8642-9e59a0ff9c91.png)
